### PR TITLE
restructure readme, add additional guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ The slides for the maptime postgis-101 workshop/tutorial can be found in postgis
 
 Some great Guides for learning PostgreSQL and postGIS:
 
-- [Introduction to postGIS](http://workshops.boundlessgeo.com/postgis-intro/index.html)
+- [Introduction to postGIS by Boundless](http://workshops.boundlessgeo.com/postgis-intro/index.html)
 - [PostGIS Guide for Tilemill](https://www.mapbox.com/tilemill/docs/guides/postgis-work/)
-- [Introduction to postGIS through CartoDB](https://github.com/csvsoundsystem/nicar-cartodb-postgis) postGIS section explains some basic syntax and how to do some basic tasks
+- [Introduction to postGIS through CartoDB by CSV Soundsystem](https://github.com/csvsoundsystem/nicar-cartodb-postgis) postGIS section explains some basic syntax and how to do some basic tasks
 
 ==== 
 

--- a/README.md
+++ b/README.md
@@ -1,40 +1,28 @@
 postgis-101
 ===========
-This is just a place holder for some ideas that I have for an introduction for postGIS. 
-
 Assumes audience is familiar with very basic geospatial principles (rasters and vectors) but has 
 no experience with SQL. 
 
-Slides for learning basic SQL and postGIS 
+The slides for the maptime postgis-101 workshop/tutorial can be found in postgis-101.md 
 
-=========== 
 
-- What is SQL (Databases, ugh, na na na) 
+=============
 
-- SELECT myawesomecolumn name FROM mytable; 
+Some great Guides for learning PostgreSQL and postGIS:
 
-- 
-
-====
-
-Uses Rasters (images) and Vectors, oh my! 
+- [Introduction to postGIS](http://workshops.boundlessgeo.com/postgis-intro/index.html)
+- [PostGIS Guide for Tilemill](https://www.mapbox.com/tilemill/docs/guides/postgis-work/)
+- [Introduction to postGIS through CartoDB](https://github.com/csvsoundsystem/nicar-cartodb-postgis) postGIS section explains some basic syntax and how to do some basic tasks
 
 ==== 
 
-Checkout these awesome resources: 
+For more advanced materials on postGIS and postgreSQL, checkout these awesome resources: 
 
-postGIS in Action 
+postGIS in Action (book)
 
 postGIS Cookbook (by Steve!) 
 
 ==== 
-
-Some prior (related) art:
-
-- [PostGIS Guide](https://www.mapbox.com/tilemill/docs/guides/postgis-work/)
-
-- [OSM Bright Quickstart Install](https://www.mapbox.com/tilemill/docs/guides/osm-bright-mac-quickstart/). See other install notes.
-
 
 ====
 


### PR DESCRIPTION
been relearning some postgis and postgreSQL in general lately and found that most online resources on postgreSQL assume the reader is already familiar with SQL and most postGIS resources assume the reader is familiar with postgreSQL. =( 

I added links that I found to be more helpful for those new to SQL and postgreSQL; and I removed some slides/notes that I originally wrote and is replaced by postgis-101.md
